### PR TITLE
Reduce public entries

### DIFF
--- a/conductor-config.toml
+++ b/conductor-config.toml
@@ -10,7 +10,7 @@
 [[dnas]]
   id = "basic_chat_dna"
   file = "./dna/basic-chat.dna.json"
-  hash = "QmbgNn8S1zeoVsdG4oRrPeRzDGrJnfx32HZ4agutFmwia2"
+  hash = "QmY9Asv9ivgZRwANdKFX6deYwXcVLd182uGQahGk1jP4Yk"
 
 
 # -----------  Instances  -----------

--- a/conductor-config.toml
+++ b/conductor-config.toml
@@ -10,7 +10,7 @@
 [[dnas]]
   id = "basic_chat_dna"
   file = "./dna/basic-chat.dna.json"
-  hash = "QmY9Asv9ivgZRwANdKFX6deYwXcVLd182uGQahGk1jP4Yk"
+  hash = "QmNpdWzF5T1TvLhZXbjmm5FTiq7Y8HwJ5Q63ztHv1Vi8Rg"
 
 
 # -----------  Instances  -----------

--- a/conductor-config.toml
+++ b/conductor-config.toml
@@ -10,7 +10,7 @@
 [[dnas]]
   id = "basic_chat_dna"
   file = "./dna/basic-chat.dna.json"
-  hash = "QmWiiFwedSod4VpBYdkj1MyS6pHAeY19vQwybkDhBVGH2g"
+  hash = "QmbgNn8S1zeoVsdG4oRrPeRzDGrJnfx32HZ4agutFmwia2"
 
 
 # -----------  Instances  -----------

--- a/dna-src/app.json
+++ b/dna-src/app.json
@@ -1,14 +1,7 @@
 {
-  "name": "Peer Chat",
+  "name": "Basic Chat",
   "description": "Private secure p2p chat with conversations.",
-  "authors": [
-    {
-      "indentifier": "Philip Beadle <philip.beadle@holo.host>",
-      "public_key_source": "",
-      "signature": ""
-    }
-  ],
-  "version": "0.1.0",
+  "version": "0.1.1",
   "dht": {},
   "properties": null
 }

--- a/dna-src/test/agent/messages.js
+++ b/dna-src/test/agent/messages.js
@@ -41,8 +41,6 @@ module.exports = scenario => {
   const testNewChannelParams = {
     name: 'test new conversation',
     description: 'for testing...',
-    initial_members: [],
-    public: true
   }
 
   const { config1 } = require('../config')

--- a/dna-src/zomes/chat/code/.hcbuild
+++ b/dna-src/zomes/chat/code/.hcbuild
@@ -11,32 +11,32 @@
     },
     {
       "command": "wasm-gc",
-      "arguments": ["/tmp/holochain/target/wasm32-unknown-unknown/release/peer_chat.wasm"]
+      "arguments": ["/tmp/holochain/target/wasm32-unknown-unknown/release/basic_chat.wasm"]
     },
     {
       "command": "wasm-opt",
       "arguments": [
         "-Oz",
         "--vacuum",
-        "/tmp/holochain/target/wasm32-unknown-unknown/release/peer_chat.wasm"
+        "/tmp/holochain/target/wasm32-unknown-unknown/release/basic_chat.wasm"
       ]
     },
     {
       "command": "wasm2wat",
       "arguments": [
-        "/tmp/holochain/target/wasm32-unknown-unknown/release/peer_chat.wasm",
+        "/tmp/holochain/target/wasm32-unknown-unknown/release/basic_chat.wasm",
         "-o",
-        "/tmp/holochain/target/wasm32-unknown-unknown/release/peer_chat.wat"
+        "/tmp/holochain/target/wasm32-unknown-unknown/release/basic_chat.wat"
       ]
     },
     {
       "command": "wat2wasm",
       "arguments": [
-        "/tmp/holochain/target/wasm32-unknown-unknown/release/peer_chat.wat",
+        "/tmp/holochain/target/wasm32-unknown-unknown/release/basic_chat.wat",
         "-o",
-        "/tmp/holochain/target/wasm32-unknown-unknown/release/peer_chat.wasm"
+        "/tmp/holochain/target/wasm32-unknown-unknown/release/basic_chat.wasm"
       ]
     }
   ],
-  "artifact": "/tmp/holochain/target/wasm32-unknown-unknown/release/peer_chat.wasm"
+  "artifact": "/tmp/holochain/target/wasm32-unknown-unknown/release/basic_chat.wasm"
 }

--- a/dna-src/zomes/chat/code/Cargo.lock
+++ b/dna-src/zomes/chat/code/Cargo.lock
@@ -65,6 +65,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "basic_chat"
+version = "0.0.16"
+dependencies = [
+ "derive_more 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hdk 0.0.38-alpha9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hdk_proc_macros 0.0.38-alpha9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "holochain_json_derive 0.0.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
+ "validator 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "validator_derive 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -743,21 +758,6 @@ dependencies = [
  "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "peer_chat"
-version = "0.0.16"
-dependencies = [
- "derive_more 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "hdk 0.0.38-alpha9 (registry+https://github.com/rust-lang/crates.io-index)",
- "hdk_proc_macros 0.0.38-alpha9 (registry+https://github.com/rust-lang/crates.io-index)",
- "holochain_json_derive 0.0.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
- "validator 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "validator_derive 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/dna-src/zomes/chat/code/Cargo.toml
+++ b/dna-src/zomes/chat/code/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-  name = "peer_chat"
+  name = "basic_chat"
   version = "0.0.16"
   authors = ["willem <willemolding@gmail.com>, Philip Beadle <philip.beadle@holo.host>"]
   edition = "2018"

--- a/dna-src/zomes/chat/code/src/conversation/handlers.rs
+++ b/dna-src/zomes/chat/code/src/conversation/handlers.rs
@@ -12,7 +12,8 @@ use crate::{
     DirectMessage,
     NotificationSignalPayload,
     JoinChannelSignalPayload,
-    MESSAGE_ENTRY
+    MESSAGE_ENTRY,
+    PUBLIC_STREAM_LINK_TYPE_TO,
 };
 use crate::conversation::Conversation;
 use crate::message;
@@ -97,12 +98,10 @@ pub fn handle_start_conversation(
     members_to_add.extend(initial_members);
     for member in members_to_add {
         if !existing_members.contains(&member) {
-            hdk::utils::link_entries_bidir(
-                &member,
+            hdk::link_entries(
                 &conversation_address,
-                "member_of",
-                "has_member",
-                "",
+                &AGENT_ADDRESS,
+                PUBLIC_STREAM_LINK_TYPE_TO,
                 "",
             )?;
         }
@@ -113,12 +112,10 @@ pub fn handle_start_conversation(
 pub fn handle_join_conversation(conversation_address: Address) -> ZomeApiResult<()> {
     let existing_members = handle_get_members(conversation_address.clone())?;
     if !existing_members.contains(&AGENT_ADDRESS) {
-        hdk::utils::link_entries_bidir(
-            &AGENT_ADDRESS,
+        hdk::link_entries(
             &conversation_address,
-            "member_of",
-            "has_member",
-            "",
+            &AGENT_ADDRESS,
+            PUBLIC_STREAM_LINK_TYPE_TO,
             "",
         )?;
     }

--- a/dna-src/zomes/chat/code/src/conversation/mod.rs
+++ b/dna-src/zomes/chat/code/src/conversation/mod.rs
@@ -14,7 +14,7 @@ pub struct Conversation {
 }
 
 use crate::{
-    MESSAGE_LINK_TYPE_TO, PUBLIC_STREAM_ENTRY, PUBLIC_STREAM_LINK_TYPE_FROM,
+    MESSAGE_LINK_TYPE_TO, PUBLIC_STREAM_ENTRY,
     PUBLIC_STREAM_LINK_TYPE_TO,
 };
 
@@ -36,18 +36,6 @@ pub fn public_conversation_definition() -> ValidatingEntryType {
             to!(
                 "%agent_id",
                 link_type: PUBLIC_STREAM_LINK_TYPE_TO,
-
-                validation_package: || {
-                    hdk::ValidationPackageDefinition::Entry
-                },
-
-                validation: |_validation_data: hdk::LinkValidationData| {
-                    Ok(())
-                }
-            ),
-            from!(
-                "%agent_id",
-                link_type: PUBLIC_STREAM_LINK_TYPE_FROM,
 
                 validation_package: || {
                     hdk::ValidationPackageDefinition::Entry

--- a/dna-src/zomes/chat/code/src/lib.rs
+++ b/dna-src/zomes/chat/code/src/lib.rs
@@ -136,9 +136,8 @@ pub mod chat {
     pub fn start_conversation(
         name: String,
         description: String,
-        initial_members: Vec<Address>,
     ) -> ZomeApiResult<Address> {
-        conversation::handlers::handle_start_conversation(name, description, initial_members)
+        conversation::handlers::handle_start_conversation(name, description)
     }
 
     #[zome_fn("hc_public")]

--- a/dna-src/zomes/chat/code/src/lib.rs
+++ b/dna-src/zomes/chat/code/src/lib.rs
@@ -32,7 +32,6 @@ pub static MESSAGE_ENTRY: &str = "message";
 pub static MESSAGE_LINK_TYPE_TO: &str = "message_in";
 pub static PUBLIC_STREAM_ENTRY: &str = "public_conversation";
 pub static PUBLIC_STREAM_LINK_TYPE_TO: &str = "has_member";
-pub static PUBLIC_STREAM_LINK_TYPE_FROM: &str = "member_of";
 
 pub const CHANNEL_MESSAGE_SIGNAL_TYPE: &str = "new_convo_message";
 pub const JOIN_CHANNEL_SIGNAL_TYPE: &str = "join_convo_message";

--- a/dna-src/zomes/chat/code/src/member/handlers.rs
+++ b/dna-src/zomes/chat/code/src/member/handlers.rs
@@ -5,8 +5,10 @@ use hdk::{
     holochain_json_api::json::RawString,
     holochain_persistence_api::cas::content::Address,
     AGENT_ADDRESS,
+    prelude::{QueryResult, QueryArgsOptions},
 };
 use crate::utils::{get_links_and_load_type, GetLinksLoadResult};
+use std::convert::TryFrom;
 
 pub fn handle_register(name: String, avatar_url: String) -> ZomeApiResult<Address> {
     let anchor_entry = Entry::App("anchor".into(), RawString::from("member_directory").into());
@@ -43,6 +45,20 @@ pub fn handle_get_member_profile(agent_address: Address) -> ZomeApiResult<Profil
     .map(|elem: &GetLinksLoadResult<Profile>| elem.entry.clone())
 }
 
+/// Get your own member profile from your local chain always to save network requests
 pub fn handle_get_my_member_profile() -> ZomeApiResult<Profile> {
-    handle_get_member_profile(AGENT_ADDRESS.to_string().into())
+    if let QueryResult::Entries(results) = hdk::query_result(
+        "chat_profile".into(),
+        QueryArgsOptions{ entries: true, ..Default::default()}
+    )? {
+        if let Some((_, Entry::App(_, entry_value))) = results.last() {
+            Ok(Profile::try_from(entry_value).expect("Invalid profile data encountered"))
+        } else {
+            Err(ZomeApiError::Internal(
+                "Agent does not have a profile registered".into(),
+            ))
+        }
+    } else {
+        unreachable!()
+    }
 }

--- a/ui-src/src/components/ConversationList/index.js
+++ b/ui-src/src/components/ConversationList/index.js
@@ -23,9 +23,8 @@ export const ConversationList = ({
 
   return (<ul className={style.component}>
     {conversations.map(conversation => {
-      const messageKeys = Object.keys(messages[conversation.id] || {})
-      const latestMessage =
-        messageKeys.length > 0 && messages[conversation.id][messageKeys.pop()]
+      const convoMessages = (messages[conversation.id] || [])
+      const latestMessage = convoMessages.sort((a, b) => { return b.createdAt - a.createdAt })[0]
       return (
         <li
           key={conversation.id}

--- a/ui-src/src/index.js
+++ b/ui-src/src/index.js
@@ -104,7 +104,6 @@ export class View extends React.Component {
         const conversationSpec = {
           name: options.name,
           description: '',
-          initial_members: []
         }
         this.makeHolochainCall(INSTANCE_ID + '/chat/start_conversation', conversationSpec, (result) => {
           console.log('created conversation', result)


### PR DESCRIPTION
Aims to reduce the network load by only making get requests when absolutely necessary.

- Checks if an agent has already joined a channel are done using the chain
- An agent retrieves their own identity on the local chain 